### PR TITLE
Revert development config back to 'alphagov' defaults

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,7 @@ jobs:
         ruby-version: 2.6.5
 
     - name: Install PostgreSQL 11 client
-      run: |
-        sudo apt-get -yqq install libpq-dev
+      run: sudo apt-get -yqq install libpq-dev
 
     - uses: actions/cache@v1
       with:
@@ -38,11 +37,14 @@ jobs:
         RAILS_ENV: test
         DB_USERNAME: postgres
       run: |
-        gem install bundler
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake db:create
         bundle exec rake db:migrate
+
+    - name: Run Rubocop linter
+      run: bundle exec rubocop
+
     - name: Run Tests
       env:
         PGHOST: localhost

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,16 +20,18 @@ class ApplicationController < ActionController::Base
       password: ENV.fetch("BASIC_AUTH_PASSWORD"),
     )
   end
-  
+
   before_action :set_locale
-  
+
   def set_locale
     I18n.locale = extract_locale || I18n.default_locale
   end
+
   def extract_locale
     parsed_locale = params[:locale]
     I18n.available_locales.map(&:to_s).include?(parsed_locale) ? parsed_locale : nil
-  end  
+  end
+
   def default_url_options
     { locale: I18n.locale }
   end

--- a/config/database.yml
+++ b/config/database.yml
@@ -3,17 +3,10 @@ default: &default
   encoding: unicode
   pool: 12
   template: template0
-  database: database
-  host: db
-  username: postgres
-  port: 5432
 
 development:
   <<: *default
-  database: database
-  host: db
-  username: postgres
-  port: 5432
+  database: coronavirus_find_support_form_development
   url: <%= ENV["DATABASE_URL"]%>
 
 test:

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,7 +58,6 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-  config.file_watcher = ActiveSupport::FileUpdateChecker
+  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.analytics_tracking_id = "DEV-123456"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,88 +1,86 @@
 # frozen_string_literal: true
-    
+
 Rails.application.routes.draw do
   scope "(:locale)", locale: /#{I18n.available_locales.join("|")}/ do
+    # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+    get "/healthcheck", to: proc { [200, {}, %w[OK]] }
 
-      # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
-      get "/healthcheck", to: proc { [200, {}, %w[OK]] }
-    
-      get "/", to: redirect("/urgent-medical-help")
-    
-      scope module: "coronavirus_form" do
-        get "/privacy", to: "privacy#show"
-        get "/cookies", to: "cookies#show"
-        get "/accessibility-statement", to: "accessibility_statement#show"
-    
-        # Question: Do you need urgent medical help?
-        get "/urgent-medical-help", to: "urgent_medical_help#show"
-        post "/urgent-medical-help", to: "urgent_medical_help#submit"
-    
-        # NHS Triage: Get urgent help from the NHS now
-        get "/get-help-from-nhs", to: "get_help_from_nhs#show"
-    
-        # Question: "Do you feel safe where you live?"
-        get "/feel-safe", to: "feel_safe#show"
-        post "/feel-safe", to: "feel_safe#submit"
-    
-        # Question: Are you finding it hard to afford rent, your mortgage or bills?
-        get "/afford-rent-mortgage-bills", to: "afford_rent_mortgage_bills#show"
-        post "/afford-rent-mortgage-bills", to: "afford_rent_mortgage_bills#submit"
-    
-        # Question: "Are you finding it hard to afford food?"
-        get "/afford-food", to: "afford_food#show"
-        post "/afford-food", to: "afford_food#submit"
-    
-        # Question: Are you able to get food?
-        get "/get-food", to: "get_food#show"
-        post "/get-food", to: "get_food#submit"
-    
-        # Question: Have you been made unemployed or put on temporary leave (furloughed)?
-        get "/have-you-been-made-unemployed", to: "have_you_been_made_unemployed#show"
-        post "/have-you-been-made-unemployed", to: "have_you_been_made_unemployed#submit"
-    
-        # Question: Are you off work because you’re ill or self-isolating?
-        get "/are-you-off-work-ill", to: "are_you_off_work_ill#show"
-        post "/are-you-off-work-ill", to: "are_you_off_work_ill#submit"
-    
-        # Question: Are you self-employed or a sole trader?
-        get "/self-employed", to: "self_employed#show"
-        post "/self-employed", to: "self_employed#submit"
-    
-        # Question: Are you worried about going into work because you live with someone vulnerable to coronavirus?
-        get "/living-with-vulnerable", to: "living_with_vulnerable#show"
-        post "/living-with-vulnerable", to: "living_with_vulnerable#submit"
-    
-        # Question: Have you got somewhere to live?
-        get "/have-somewhere-to-live", to: "have_somewhere_to_live#show"
-        post "/have-somewhere-to-live", to: "have_somewhere_to_live#submit"
-    
-        # Question: Have you been evicted?
-        get "/have-you-been-evicted", to: "have_you_been_evicted#show"
-        post "/have-you-been-evicted", to: "have_you_been_evicted#submit"
-    
-        # Question: Are you worried about your mental health or someone else's mental health?
-        get "/mental-health-worries", to: "mental_health_worries#show"
-        post "/mental-health-worries", to: "mental_health_worries#submit"
-    
-        # Question: Are you able to leave your home if absolutely necessary?
-        get "/able-to-leave", to: "able_to_leave#show"
-        post "/able-to-leave", to: "able_to_leave#submit"
-    
-        # Question: What do you need to find help with?
-        get "/need-help-with", to: "need_help_with#show"
-        post "/need-help-with", to: "need_help_with#submit"
-    
-        # Results
-        get "/results", to: "results#show"
-    
-        get "/clear-session", to: "session#delete"
-    
-        get "/session-expired", to: "session_expired#show"
-    
-        get "/data-export", to: "data_export#show"
-      end
-    
-      mount GovukPublishingComponents::Engine, at: "/component-guide"
+    get "/", to: redirect("/urgent-medical-help")
+
+    scope module: "coronavirus_form" do
+      get "/privacy", to: "privacy#show"
+      get "/cookies", to: "cookies#show"
+      get "/accessibility-statement", to: "accessibility_statement#show"
+
+      # Question: Do you need urgent medical help?
+      get "/urgent-medical-help", to: "urgent_medical_help#show"
+      post "/urgent-medical-help", to: "urgent_medical_help#submit"
+
+      # NHS Triage: Get urgent help from the NHS now
+      get "/get-help-from-nhs", to: "get_help_from_nhs#show"
+
+      # Question: "Do you feel safe where you live?"
+      get "/feel-safe", to: "feel_safe#show"
+      post "/feel-safe", to: "feel_safe#submit"
+
+      # Question: Are you finding it hard to afford rent, your mortgage or bills?
+      get "/afford-rent-mortgage-bills", to: "afford_rent_mortgage_bills#show"
+      post "/afford-rent-mortgage-bills", to: "afford_rent_mortgage_bills#submit"
+
+      # Question: "Are you finding it hard to afford food?"
+      get "/afford-food", to: "afford_food#show"
+      post "/afford-food", to: "afford_food#submit"
+
+      # Question: Are you able to get food?
+      get "/get-food", to: "get_food#show"
+      post "/get-food", to: "get_food#submit"
+
+      # Question: Have you been made unemployed or put on temporary leave (furloughed)?
+      get "/have-you-been-made-unemployed", to: "have_you_been_made_unemployed#show"
+      post "/have-you-been-made-unemployed", to: "have_you_been_made_unemployed#submit"
+
+      # Question: Are you off work because you’re ill or self-isolating?
+      get "/are-you-off-work-ill", to: "are_you_off_work_ill#show"
+      post "/are-you-off-work-ill", to: "are_you_off_work_ill#submit"
+
+      # Question: Are you self-employed or a sole trader?
+      get "/self-employed", to: "self_employed#show"
+      post "/self-employed", to: "self_employed#submit"
+
+      # Question: Are you worried about going into work because you live with someone vulnerable to coronavirus?
+      get "/living-with-vulnerable", to: "living_with_vulnerable#show"
+      post "/living-with-vulnerable", to: "living_with_vulnerable#submit"
+
+      # Question: Have you got somewhere to live?
+      get "/have-somewhere-to-live", to: "have_somewhere_to_live#show"
+      post "/have-somewhere-to-live", to: "have_somewhere_to_live#submit"
+
+      # Question: Have you been evicted?
+      get "/have-you-been-evicted", to: "have_you_been_evicted#show"
+      post "/have-you-been-evicted", to: "have_you_been_evicted#submit"
+
+      # Question: Are you worried about your mental health or someone else's mental health?
+      get "/mental-health-worries", to: "mental_health_worries#show"
+      post "/mental-health-worries", to: "mental_health_worries#submit"
+
+      # Question: Are you able to leave your home if absolutely necessary?
+      get "/able-to-leave", to: "able_to_leave#show"
+      post "/able-to-leave", to: "able_to_leave#submit"
+
+      # Question: What do you need to find help with?
+      get "/need-help-with", to: "need_help_with#show"
+      post "/need-help-with", to: "need_help_with#submit"
+
+      # Results
+      get "/results", to: "results#show"
+
+      get "/clear-session", to: "session#delete"
+
+      get "/session-expired", to: "session_expired#show"
+
+      get "/data-export", to: "data_export#show"
+    end
+
+    mount GovukPublishingComponents::Engine, at: "/component-guide"
   end
-
 end

--- a/lando/rails-db-setup.sh
+++ b/lando/rails-db-setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-DATABASE_URL="postgres://postgres:@db:5432/database" rails db:setup
+DATABASE_URL="postgres://postgres:@db:5432" TEST_DATABASE_URL="postgres://postgres:@db:5432" rails db:setup

--- a/spec/support/fill_in_the_form_steps.rb
+++ b/spec/support/fill_in_the_form_steps.rb
@@ -126,7 +126,7 @@ module FillInTheFormSteps
 
   def they_view_the_results_page
     expect(page).to have_content(I18n.t("coronavirus_form.results.header.title"))
-    expect(current_path).to eq "/results"
+    expect(current_path).to eq "/en/results"
   end
 
   def they_are_provided_with_information_about_feeling_unsafe


### PR DESCRIPTION
Revert some development changes (required for the *govwales* prototyping) back to the defaults, to avoid discrepancies between local development environments.