### PR TITLE
Add autoprefixer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem "sass-rails", "< 6"
 gem "sentry-raven", "~> 3.0"
 gem "uglifier", "~> 4.2"
 
+gem "autoprefixer-rails" # GOV.WALES specific gem
+
 group :development do
   gem "listen", "~> 3"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
       capybara (~> 3.13, < 4)
       websocket-driver (>= 0.6.5)
     ast (2.4.0)
+    autoprefixer-rails (9.7.6)
+      execjs
     awesome_print (1.8.0)
     bootsnap (1.4.6)
       msgpack (~> 1.0)
@@ -340,6 +342,7 @@ PLATFORMS
 
 DEPENDENCIES
   apparition (~> 0.5.0)
+  autoprefixer-rails
   awesome_print (~> 1.8)
   bootsnap (~> 1)
   byebug (~> 11)

--- a/app/assets/stylesheets/govwales/base/_global.scss
+++ b/app/assets/stylesheets/govwales/base/_global.scss
@@ -5,10 +5,7 @@ html {
 
 html.govuk-template {
   background-color: initial;
-  -webkit-text-size-adjust: none;
-  -moz-text-size-adjust: none;
-  -ms-text-size-adjust: none;
-  text-size-adjust: none;
+  text-size-adjust: auto;
 }
 
 body > .govuk-width-container,


### PR DESCRIPTION
Add the `autoprefixer` gem (https://github.com/ai/autoprefixer-rails) to automate browser prefixes.

Note:  In a development environment, you'll need to run `bin/rails tmp:clear` after initially installation of this gem (one off task)